### PR TITLE
fix: kill sidecar reliably on Windows (v0.2.1 hotfix)

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -52,12 +52,46 @@ function startSidecar(): void {
   console.log(`[main] Backend sidecar started (pid ${sidecarProcess.pid})`)
 }
 
-function stopSidecar(): void {
-  if (sidecarProcess) {
-    console.log('[main] Stopping backend sidecar…')
-    sidecarProcess.kill()
+function stopSidecar(): Promise<void> {
+  const proc = sidecarProcess
+  if (!proc || proc.exitCode !== null || !proc.pid) {
     sidecarProcess = null
+    return Promise.resolve()
   }
+
+  const pid = proc.pid
+  sidecarProcess = null
+  console.log(`[main] Stopping backend sidecar (pid ${pid})…`)
+
+  const exited = new Promise<void>((resolve) => {
+    if (proc.exitCode !== null) {
+      resolve()
+      return
+    }
+    proc.once('exit', () => resolve())
+  })
+
+  if (process.platform === 'win32') {
+    // child.kill() on Windows is unreliable for cross-compiled Go binaries:
+    // it can leave the process alive, holding file locks on the installed
+    // .exe. That blocks the NSIS installer/uninstaller and auto-updater
+    // ("application is still open"). taskkill /F /T terminates the process
+    // tree synchronously at the OS level.
+    spawn('taskkill', ['/F', '/T', '/PID', String(pid)], { stdio: 'ignore' })
+      .on('error', (err) => {
+        console.error('[main] taskkill failed:', err.message)
+        try { proc.kill('SIGKILL') } catch { /* already gone */ }
+      })
+  } else {
+    proc.kill('SIGTERM')
+  }
+
+  // Bound the wait — if the child really is wedged we still let Electron exit
+  // rather than hang forever.
+  return Promise.race([
+    exited,
+    new Promise<void>((resolve) => setTimeout(resolve, 5000)),
+  ])
 }
 
 // ── Auto-updater ──────────────────────────────────────────────────────────────
@@ -570,7 +604,11 @@ ipcMain.handle('updater:download', () => {
   if (!isDev) autoUpdater.downloadUpdate()
 })
 
-ipcMain.handle('updater:quit-and-install', () => {
+ipcMain.handle('updater:quit-and-install', async () => {
+  // Kill the sidecar before handing off to the updater. quitAndInstall exits
+  // the main process quickly; if the sidecar is still alive the NSIS updater
+  // cannot replace pq-companion-server.exe and the install wedges.
+  await stopSidecar()
   autoUpdater.quitAndInstall(true, true)
 })
 
@@ -589,13 +627,20 @@ app.whenReady().then(() => {
   })
 })
 
+let isGracefulQuit = false
+
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
-    stopSidecar()
     app.quit()
   }
 })
 
-app.on('before-quit', () => {
-  stopSidecar()
+app.on('before-quit', (event) => {
+  if (isGracefulQuit || !sidecarProcess) return
+  // Electron only waits for before-quit synchronously. To stop the sidecar
+  // and confirm exit before we really quit, cancel this pass, run the async
+  // cleanup, then quit again with the flag set.
+  event.preventDefault()
+  isGracefulQuit = true
+  stopSidecar().finally(() => app.quit())
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pq-companion",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Desktop companion app for Project Quarm (EverQuest emulated server)",
   "main": "out/main/index.js",
   "author": "jasonsoprovich",


### PR DESCRIPTION
## Summary
- Fixes the installer/updater hang where users cannot install or uninstall PQ Companion because the Go sidecar (`pq-companion-server.exe`) is left running after quit, holding a lock on its own executable.
- Root cause: `child.kill()` on Windows does not reliably terminate cross-compiled Go binaries. When `autoUpdater.quitAndInstall()` exited the main process, the sidecar was orphaned and NSIS aborted with "the application is still open."
- Fix: `stopSidecar()` now uses `taskkill /F /T /PID` on Windows, awaits the child's exit (bounded 5s), and is awaited by `updater:quit-and-install` and `before-quit` before the app actually exits.

## Changes
- `electron/main/index.ts` — async `stopSidecar`, taskkill on Windows, `before-quit` preventDefault + async cleanup, `updater:quit-and-install` awaits the kill.
- `package.json` — version bump 0.2.0 → 0.2.1.

## Test plan
- [ ] Fresh install on a clean Windows VM
- [ ] Launch, quit via window close — confirm `pq-companion-server.exe` gone in Task Manager Details tab
- [ ] Trigger auto-update from 0.2.0 → 0.2.1 — confirm installer replaces files without the "still open" error
- [ ] Uninstall via Settings → Apps succeeds

## Known NOT fixed (follow-ups)
- Code signing still unsigned — `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` secrets are empty in CI (`cscInfo=null` in release log). SmartScreen will still warn. Separate issue.
- `ci.yml` is failing on a stale `TestLoadFrom_createsDefaultFile` (opacity default). Release workflow does not gate on it, so this hotfix still releases, but should be fixed next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)